### PR TITLE
Allow requester to define whether they want a full status or not

### DIFF
--- a/iiif/profiles/base.py
+++ b/iiif/profiles/base.py
@@ -171,15 +171,17 @@ class AbstractProfile(abc.ABC):
         """
         pass
 
-    async def get_status(self) -> dict:
+    async def get_status(self, full: bool = False) -> dict:
         """
         Returns some stats about the profile.
 
         :return: a dict of stats
         """
-        return {
+        status = {
             'name': self.name,
             'info_json_cache_size': len(self.info_json_cache),
-            'sources': get_path_stats(self.source_path),
-            'cache': get_path_stats(self.cache_path),
         }
+        if full:
+            status['sources'] = get_path_stats(self.source_path)
+            status['cache'] = get_path_stats(self.cache_path)
+        return status

--- a/iiif/profiles/mss.py
+++ b/iiif/profiles/mss.py
@@ -363,13 +363,13 @@ class MSSProfile(AbstractProfile):
         self.ic_fast_pool.shutdown()
         self.ic_slow_pool.shutdown()
 
-    async def get_status(self) -> dict:
+    async def get_status(self, full: bool = False) -> dict:
         """
         Returns some nice stats about what the runners are up to and such.
 
         :return: a dict of stats
         """
-        status = await super().get_status()
+        status = await super().get_status(full)
         runners = (self.doc_runner, self.fetch_runner)
         status['runners'] = {
             runner.name: await runner.get_status() for runner in runners

--- a/iiif/web.py
+++ b/iiif/web.py
@@ -34,10 +34,12 @@ async def on_shutdown():
 
 
 @app.get('/status')
-async def status() -> dict:
+async def status(full: bool = False) -> dict:
     """
     Returns the status of the server along with some stats about current resource usages.
 
+    :param full: boolean parameter indicating whether to provide a full status or just the
+                 essentials. The full status may take longer to generate. Default: False.
     :return: a dict
     """
     return {
@@ -45,7 +47,7 @@ async def status() -> dict:
         'default_profile': state.config.default_profile_name,
         'processing': state.dispatcher.get_status(),
         'profiles': {
-            profile.name: await profile.get_status()
+            profile.name: await profile.get_status(full)
             for profile in state.profiles.values()
         }
     }


### PR DESCRIPTION
On a proper server the source and cache directories can get pretty large so it takes a while to get their size. /status?full=false (the default) avoids this for simple, is the server running, status requests.