### PR TITLE
Use pillow for rotations instead of jpegtran

### DIFF
--- a/iiif/ops.py
+++ b/iiif/ops.py
@@ -1,8 +1,7 @@
+from contextlib import suppress
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-
-from contextlib import suppress
 
 from iiif.exceptions import InvalidIIIFParameter
 from iiif.profiles.base import ImageInfo
@@ -152,9 +151,8 @@ def parse_size(size: str, region: Region) -> Size:
 
 @dataclass
 class Rotation:
-    # jpegtran only supports rotating in 90 degree increments and IIIF suggests only supporting
-    # rotating by 90 unless the png format is supported so that the background can be made
-    # transparent
+    # IIIF suggests only supporting rotating by 90 unless the png format is supported so that the
+    # background can be made transparent
     angle: int
     mirror: bool = False
 

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -3,7 +3,7 @@
 
 import hashlib
 import pytest
-from PIL import Image
+from PIL import Image, ImageOps
 from jpegtran import JPEGImage
 from pathlib import Path
 from queue import Queue
@@ -96,7 +96,7 @@ class TestProcessRotation:
 
     def test_rotate(self, image: JPEGImage):
         result = process_rotation(image, Rotation(90))
-        assert_same(result, image.rotate(90))
+        assert_same(result, to_pillow(image).rotate(90))
 
     def test_mirror(self, image: JPEGImage):
         result = process_rotation(image, Rotation(0, mirror=True))
@@ -104,7 +104,7 @@ class TestProcessRotation:
 
     def test_rotate_and_mirror(self, image: JPEGImage):
         result = process_rotation(image, Rotation(90, mirror=True))
-        assert_same(result, image.flip('horizontal').rotate(90))
+        assert_same(result, ImageOps.mirror(to_pillow(image)).rotate(90))
 
 
 class TestQuality:


### PR DESCRIPTION
Just easier really and avoids the errors. We could write some logic to only rotate/flip with jpegtran if the image width and height are divisible by 16 but quite frankly it's just easier not to. If performance becomes an issue here then that's a thing we can do.

Closes https://github.com/NaturalHistoryMuseum/iiif-image-server/issues/16