### PR TITLE
Fix rotation bugs

### DIFF
--- a/iiif/processing.py
+++ b/iiif/processing.py
@@ -78,7 +78,7 @@ def process_rotation(image: JPEGImage, rotation: Rotation) -> JPEGImage:
     if rotation.mirror:
         pillow_image = ImageOps.mirror(pillow_image)
     if rotation.angle > 0:
-        pillow_image = pillow_image.rotate(rotation.angle)
+        pillow_image = pillow_image.rotate(-rotation.angle, expand=True)
     return to_jpegtran(pillow_image)
 
 

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -96,7 +96,7 @@ class TestProcessRotation:
 
     def test_rotate(self, image: JPEGImage):
         result = process_rotation(image, Rotation(90))
-        assert_same(result, to_pillow(image).rotate(90))
+        assert_same(result, to_pillow(image).rotate(-90, expand=True))
 
     def test_mirror(self, image: JPEGImage):
         result = process_rotation(image, Rotation(0, mirror=True))
@@ -104,7 +104,7 @@ class TestProcessRotation:
 
     def test_rotate_and_mirror(self, image: JPEGImage):
         result = process_rotation(image, Rotation(90, mirror=True))
-        assert_same(result, ImageOps.mirror(to_pillow(image)).rotate(90))
+        assert_same(result, ImageOps.mirror(to_pillow(image)).rotate(-90, expand=True))
 
 
 class TestQuality:


### PR DESCRIPTION
- pillow rotates counter-clockwise, so we need to negate the angle
  for IIIF which rotates clockwise
- use the expand parameter for pillow to do the right thing when
  rotating non-square images