### PR TITLE
Add a redirect endpoint for old mam requests to go to

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout source code

--- a/iiif/profiles/mss.py
+++ b/iiif/profiles/mss.py
@@ -55,6 +55,20 @@ class MSSStoreFailure(IIIFServerException):
                              f'{cause.url} due to {cause.cause}')
 
 
+class AssetIDNotFound(IIIFServerException):
+
+    def __init__(self, asset_id: str):
+        super().__init__(f"Asset ID {asset_id} not found", status_code=404)
+
+
+class AssetIDDuplicateGUIDs(IIIFServerException):
+
+    def __init__(self, asset_id: str, total: int):
+        super().__init__(f"Asset ID {asset_id} matched multiple images", status_code=404,
+                         log=f"Asset ID {asset_id} matched multiple {total} GUIDs")
+        self.total = total
+
+
 class MSSStoreNoLength(IIIFServerException):
 
     def __init__(self, profile: str, name: str):
@@ -77,6 +91,8 @@ class MSSImageInfo(ImageInfo):
         self.emu_irn = doc['id']
         # the name of the original file as it appears on the actual filesystem EMu is using
         self.original = doc['file']
+        # the old MAM asset ID value, if there is one
+        self.old_asset_id = doc.get('old_asset_id')
         # a list of the EMu generated derivatives of the original file. The list should already be
         # in the ascending (width, height) order because the import process sorts it
         self.derivatives = doc.get('derivatives', [])
@@ -331,6 +347,20 @@ class MSSProfile(AbstractProfile):
             log_error(e)
             raise e
 
+    async def convert_guid_to_asset_id(self, asset_id: str) -> str:
+        """
+        Given an old MAM asset ID, see if we can convert it into a GUID.
+
+        :param asset_id: the old MAM asset ID
+        :return: the matching GUID
+        """
+        total, guid = await self.es_handler.lookup_guid(asset_id)
+        if total == 0:
+            raise AssetIDNotFound(asset_id)
+        elif total > 1:
+            raise AssetIDDuplicateGUIDs(asset_id, total)
+        return guid
+
     async def close(self):
         """
         Close down this profile.
@@ -371,11 +401,29 @@ class MSSElasticsearchHandler:
         search_url = f'{next(self.es_hosts)}/{self.mss_index}/_search'
         search = Search().filter('term', **{'guid.keyword': guid}).extra(size=1)
         async with self.es_session.post(search_url, json=search.to_dict()) as response:
-            text = await response.text(encoding='utf-8')
-            result = json.loads(text)
+            result = await response.json(encoding='utf-8')
             total = result['hits']['total']
             first_doc = next((doc['_source'] for doc in result['hits']['hits']), None)
             return total, first_doc
+
+    async def lookup_guid(self, asset_id: str) -> Tuple[int, Optional[str]]:
+        """
+        Given an old MAM asset ID, lookup the associated GUID.
+
+        :param asset_id: the old MAM asset ID
+        :return: the total hits and the GUID (or None if there are no hits)
+        """
+        search_url = f'{next(self.es_hosts)}/{self.mss_index}/_search'
+        search = Search().filter('term', **{'old_asset_id.keyword': asset_id}).extra(size=1)
+        async with self.es_session.post(search_url, json=search.to_dict()) as response:
+            result = await response.json(encoding='utf-8')
+            total = result['hits']['total']
+            first_doc = next((doc['_source'] for doc in result['hits']['hits']), None)
+            if first_doc:
+                guid = first_doc['guid']
+            else:
+                guid = None
+            return total, guid
 
     async def get_status(self) -> dict:
         """

--- a/iiif/routers/mam.py
+++ b/iiif/routers/mam.py
@@ -1,0 +1,37 @@
+from fastapi import APIRouter
+from starlette.requests import Request
+from starlette.responses import RedirectResponse
+
+from iiif.profiles.mss import MSSProfile
+from iiif.state import state
+
+router = APIRouter()
+
+
+@router.get('/mam/{asset_id}')
+async def mam_redirect(request: Request, asset_id: str) -> RedirectResponse:
+    """
+    When an old MAM URL is requested, it is now redirected to this endpoint. This endpoint looks up
+    the old asset ID and then redirects base simple image endpoint using the GUID instead of the
+    asset ID.
+    If the MSS is the default profile then the mss: is omitted, if not then it is included.
+    \f
+
+    :param request: the request object
+    :param asset_id: the MAM asset ID
+    :return: a RedirectResponse to the MSS preview endpoint
+    """
+    mss_profile: MSSProfile = state.get_profile('mss')
+    # convert the asset ID into a GUID
+    guid = await mss_profile.convert_guid_to_asset_id(asset_id)
+
+    if state.config.default_profile_name == 'mss':
+        # if the default profile is the mss profile, redirect to just guid for nice clean URLs
+        identifier = guid
+    else:
+        # otherwise, create the full identifier with profile name
+        identifier = f'mss:{guid}'
+    # this seems to be the easiest way to ensure we redirect to a sensible path given we may be
+    # under some custom subpath via a proxy
+    path = request.url.path.replace(f'/mam/{asset_id}', f'/{identifier}')
+    return RedirectResponse(path)

--- a/iiif/web.py
+++ b/iiif/web.py
@@ -11,7 +11,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from starlette.responses import JSONResponse, StreamingResponse
 
 from iiif.exceptions import handler, IIIFServerException
-from iiif.routers import iiif, originals, simple
+from iiif.routers import iiif, originals, simple, mam
 from iiif.state import state
 
 # disable DecompressionBombErrors
@@ -100,4 +100,5 @@ app.add_exception_handler(IIIFServerException, handler)
 # order matters here btw!
 app.include_router(originals.router)
 app.include_router(simple.router)
+app.include_router(mam.router)
 app.include_router(iiif.router)

--- a/iiif/web.py
+++ b/iiif/web.py
@@ -99,6 +99,6 @@ app.add_exception_handler(IIIFServerException, handler)
 
 # order matters here btw!
 app.include_router(originals.router)
-app.include_router(simple.router)
 app.include_router(mam.router)
+app.include_router(simple.router)
 app.include_router(iiif.router)


### PR DESCRIPTION
This will require something on the old mam side to redirect to /mam/{asset_id} at which point we will essentially convert that to a GUID and redirect again to the right place.

This will return 404s until the MSS has the old asset IDs added.