### PR TITLE
Switch to using a Loky process pool

### DIFF
--- a/iiif/config.py
+++ b/iiif/config.py
@@ -22,8 +22,11 @@ class Config:
         # info.json settings
         self.min_sizes_size = options.get('min_sizes_size', 200)
 
+        # process pool settings
+        self.pool_size = options.get('pool_size', os.cpu_count())
+        self.pool_recycle_time = options.get('pool_recycle_time', 10)
+
         # image processing settings
-        self.processing_pool_size = options.get('processing_pool_size', 2)
         self.processed_cache_size = options.get('processed_cache_size', 1024 * 1024 * 256)
         self.processed_cache_ttl = options.get('processed_cache_ttl', 12 * 60 * 60)
 

--- a/iiif/profiles/__init__.py
+++ b/iiif/profiles/__init__.py
@@ -1,3 +1,5 @@
+from concurrent.futures import Executor
+
 from copy import deepcopy
 from typing import Dict
 
@@ -12,11 +14,12 @@ registry = {
 }
 
 
-def load_profiles(config: Config) -> Dict[str, AbstractProfile]:
+def load_profiles(config: Config, pool: Executor) -> Dict[str, AbstractProfile]:
     """
     Given the config object, create all the profiles that are defined within it and return them.
 
     :param config: the config object
+    :param pool: pool for offloaded processing
     :return: a dict of profiles keyed by name
     """
     profiles = {}
@@ -27,5 +30,5 @@ def load_profiles(config: Config) -> Dict[str, AbstractProfile]:
         # here's that pop, wow!
         profile_creator = registry[options.pop('type')]
         rights = options.pop('rights')
-        profiles[name] = profile_creator(name, config, rights, **options)
+        profiles[name] = profile_creator(name, config, pool, rights, **options)
     return profiles

--- a/iiif/profiles/base.py
+++ b/iiif/profiles/base.py
@@ -1,3 +1,5 @@
+from concurrent.futures import Executor
+
 import abc
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -49,16 +51,19 @@ class AbstractProfile(abc.ABC):
     jpeg file, it can be processed in a common way (see the processing module).
     """
 
-    def __init__(self, name: str, config: Config, rights: str, cache_for: float = 60):
+    def __init__(self, name: str, config: Config, pool: Executor, rights: str,
+                 cache_for: float = 60, **kwargs):
         """
         :param name: the name of the profile, should be unique across profiles
         :param config: the config object
+        :param pool: the general purpose pool for offloading processing if necessary
         :param rights: the rights definition for all images handled by this profile
         :param cache_for: how long in seconds a client should cache the results from this profile
                           (both info.json and image data)
         """
         self.name = name
         self.config = config
+        self.pool = pool
         # this is where all of our source images will be stored
         self.source_path = config.source_path / name
         # this is where all of our processed images will be stored

--- a/iiif/web.py
+++ b/iiif/web.py
@@ -55,7 +55,7 @@ async def on_shutdown():
     """
     for profile in state.profiles.values():
         await profile.close()
-    state.processor.stop()
+    state.pool.shutdown()
 
 
 @app.get('/status')

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     pyyaml==6.0
     uvicorn[standard]==0.17.6
     wand==0.6.7
+    loky==3.1.0
 
 [options.extras_require]
 test =

--- a/tests/profiles/test_disk.py
+++ b/tests/profiles/test_disk.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 import math
 import pytest
 
@@ -8,7 +10,7 @@ from tests.utils import create_image
 
 @pytest.fixture(scope='function')
 def disk_profile(config):
-    return OnDiskProfile('test', config, 'http://creativecommons.org/licenses/by/4.0/')
+    return OnDiskProfile('test', config, MagicMock(), 'http://creativecommons.org/licenses/by/4.0/')
 
 
 class TestOnDiskProfile:

--- a/tests/profiles/test_mss_store.py
+++ b/tests/profiles/test_mss_store.py
@@ -1,3 +1,5 @@
+from concurrent.futures import Executor, ProcessPoolExecutor
+
 import pytest
 from PIL import Image
 from aiohttp import ClientResponseError
@@ -15,8 +17,13 @@ def source_root(tmpdir) -> Path:
     return Path(tmpdir, 'test')
 
 
-async def test_check_access_ok(source_root: Path):
-    store = MSSSourceStore(source_root, MOCK_HOST, 10, 10, 10)
+@pytest.fixture
+def pool() -> Executor:
+    return ProcessPoolExecutor(max_workers=1)
+
+
+async def test_check_access_ok(source_root: Path, pool: Executor):
+    store = MSSSourceStore(source_root, pool, MOCK_HOST, 10, 10, 10)
     emu_irn = 12345
     try:
         with aioresponses() as m:
@@ -26,8 +33,8 @@ async def test_check_access_ok(source_root: Path):
         await store.close()
 
 
-async def test_check_access_failed(source_root: Path):
-    store = MSSSourceStore(source_root, MOCK_HOST, 10, 10, 10)
+async def test_check_access_failed(source_root: Path, pool: Executor):
+    store = MSSSourceStore(source_root, pool, MOCK_HOST, 10, 10, 10)
     emu_irn = 12345
     try:
         with aioresponses() as m:
@@ -37,8 +44,8 @@ async def test_check_access_failed(source_root: Path):
         await store.close()
 
 
-async def test_stream(source_root: Path):
-    store = MSSSourceStore(source_root, MOCK_HOST, 10, 10, 10)
+async def test_stream(source_root: Path, pool: Executor):
+    store = MSSSourceStore(source_root, pool, MOCK_HOST, 10, 10, 10)
     emu_irn = 12345
     file = 'some_file.jpg'
     content = b'1234 look at me i am a jpg image'
@@ -56,9 +63,9 @@ async def test_stream(source_root: Path):
         await store.close()
 
 
-async def test_stream_access_denied(source_root):
+async def test_stream_access_denied(source_root, pool: Executor):
     source_root: Path
-    store = MSSSourceStore(source_root, MOCK_HOST, 10, 10, 10)
+    store = MSSSourceStore(source_root, pool, MOCK_HOST, 10, 10, 10)
     emu_irn = 12345
     file = 'some_file.jpg'
     try:
@@ -77,8 +84,8 @@ async def test_stream_access_denied(source_root):
         await store.close()
 
 
-async def test_stream_missing(source_root):
-    store = MSSSourceStore(source_root, MOCK_HOST, 10, 10, 10)
+async def test_stream_missing(source_root, pool: Executor):
+    store = MSSSourceStore(source_root, pool, MOCK_HOST, 10, 10, 10)
     emu_irn = 12345
     file = 'some_file.jpg'
     try:
@@ -98,8 +105,8 @@ async def test_stream_missing(source_root):
         await store.close()
 
 
-async def test_stream_use_dams(source_root: Path):
-    store = MSSSourceStore(source_root, MOCK_HOST, 10, 10, 10)
+async def test_stream_use_dams(source_root: Path, pool: Executor):
+    store = MSSSourceStore(source_root, pool, MOCK_HOST, 10, 10, 10)
     emu_irn = 12345
     file = 'some_file.jpg'
     dams_host = 'http://not.the.real.dams'
@@ -122,8 +129,8 @@ async def test_stream_use_dams(source_root: Path):
         await store.close()
 
 
-async def test_stream_dams_fails(source_root: Path):
-    store = MSSSourceStore(source_root, MOCK_HOST, 10, 10, 10)
+async def test_stream_dams_fails(source_root: Path, pool: Executor):
+    store = MSSSourceStore(source_root, pool, MOCK_HOST, 10, 10, 10)
     emu_irn = 12345
     file = 'some_file.jpg'
     dams_host = 'http://not.the.real.dams'
@@ -147,8 +154,8 @@ async def test_stream_dams_fails(source_root: Path):
         await store.close()
 
 
-async def test_use(source_root: Path):
-    store = MSSSourceStore(source_root, MOCK_HOST, 10, 10, 10)
+async def test_use(source_root: Path, pool: Executor):
+    store = MSSSourceStore(source_root, pool, MOCK_HOST, 10, 10, 10)
     emu_irn = 12345
     file = 'some_file.jpg'
 
@@ -168,8 +175,8 @@ async def test_use(source_root: Path):
         await store.close()
 
 
-async def test_get_file_size(source_root: Path):
-    store = MSSSourceStore(source_root, MOCK_HOST, 10, 10, 10)
+async def test_get_file_size(source_root: Path, pool: Executor):
+    store = MSSSourceStore(source_root, pool, MOCK_HOST, 10, 10, 10)
     emu_irn = 12345
     file = 'some_file.jpg'
     content_length = 489345
@@ -180,8 +187,8 @@ async def test_get_file_size(source_root: Path):
         assert await store.get_file_size(source) == content_length
 
 
-async def test_get_file_size_fail(source_root: Path):
-    store = MSSSourceStore(source_root, MOCK_HOST, 10, 10, 10)
+async def test_get_file_size_fail(source_root: Path, pool: Executor):
+    store = MSSSourceStore(source_root, pool, MOCK_HOST, 10, 10, 10)
     emu_irn = 12345
     file = 'some_file.jpg'
 

--- a/tests/profiles/test_mss_store.py
+++ b/tests/profiles/test_mss_store.py
@@ -15,17 +15,6 @@ def source_root(tmpdir) -> Path:
     return Path(tmpdir, 'test')
 
 
-async def test_choose_convert_pool(source_root: Path):
-    store = MSSSourceStore(source_root, MOCK_HOST, 10, 10, 10)
-    try:
-        assert store._choose_convert_pool('beans.jpg') == store._fast_pool
-        assert store._choose_convert_pool('beans.jpeg') == store._fast_pool
-        assert store._choose_convert_pool('beans.tiff') == store._slow_pool
-        assert store._choose_convert_pool('beans.any') == store._slow_pool
-    finally:
-        await store.close()
-
-
 async def test_check_access_ok(source_root: Path):
     store = MSSSourceStore(source_root, MOCK_HOST, 10, 10, 10)
     emu_irn = 12345


### PR DESCRIPTION
This provides a more robust implementation of a process executor which includes things like recycling idle processes. This should hopefully reduce our memory leak issues.

Additionally, this commit changes the way we manage processes so that there's only one general purpose process pool for offloading tasks rather than several. This makes it easier to control server resources and also it seems that with Loky you can only have 1 process pool running at once.

Annoyingly this seems to break my ability to debug functions running in the process pools in PyCharm but heyho. Maybe we could add something that switches the pool in use depending on settings/env.

Closes #30 🤞🏼 