### PR TITLE
Proactively disable Pillow bomb errors in subprocesses

### DIFF
--- a/iiif/ops.py
+++ b/iiif/ops.py
@@ -10,7 +10,7 @@ from typing import List
 
 from iiif.exceptions import InvalidIIIFParameter
 from iiif.profiles.base import ImageInfo
-from iiif.utils import to_pillow, to_jpegtran
+from iiif.utils import to_pillow, to_jpegtran, disable_bomb_errors
 
 # this server currently supports IIIF level2
 IIIF_LEVEL = 2
@@ -404,6 +404,9 @@ class IIIFOps:
         :param source_path: the source image
         :param output_path: the target location
         """
+        # given this is usually run in a separate process, make sure we have disabled bomb errors
+        disable_bomb_errors()
+
         image = JPEGImage(str(source_path))
 
         # process each op in the right order

--- a/iiif/utils.py
+++ b/iiif/utils.py
@@ -118,6 +118,8 @@ def convert_image(image_path: Path, target_path: Path, quality: int = 80,
     :param quality: the jpeg quality setting to use
     :param subsampling: the jpeg subsampling to use
     """
+    # given this is usually run in a separate process, make sure we have disabled bomb errors
+    disable_bomb_errors()
     try:
         with WandImage(filename=str(image_path)) as image:
             if image.format.lower() == 'jpeg':
@@ -404,3 +406,14 @@ class FetchCache(abc.ABC):
             'in_use': len(self._in_use),
             'waiting_clean_up': len(self._cleaners),
         }
+
+
+def disable_bomb_errors():
+    """
+    Disables DecompressionBombErrors that are thrown by Pillow when an image we're processing is too
+    large.
+    Details: https://pillow.readthedocs.io/en/latest/releasenotes/5.0.0.html#decompression-bombs-now-raise-exceptions
+    """
+    # disable DecompressionBombErrors
+    # ()
+    Image.MAX_IMAGE_PIXELS = None

--- a/iiif/web.py
+++ b/iiif/web.py
@@ -4,7 +4,6 @@ import aiohttp
 import humanize
 import platform
 import time
-from PIL import Image
 from datetime import timedelta
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -13,11 +12,9 @@ from starlette.responses import JSONResponse, StreamingResponse
 from iiif.exceptions import handler, IIIFServerException
 from iiif.routers import iiif, originals, simple
 from iiif.state import state
+from iiif.utils import disable_bomb_errors
 
-# disable DecompressionBombErrors
-# (https://pillow.readthedocs.io/en/latest/releasenotes/5.0.0.html#decompression-bombs-now-raise-exceptions)
-Image.MAX_IMAGE_PIXELS = None
-
+disable_bomb_errors()
 start_time = time.monotonic()
 app = FastAPI(title='Data Portal Image Service')
 app.add_middleware(


### PR DESCRIPTION
This seems to have become a problem post-loky, but only in production? I would assume it's because Loky is doing something different in prod when it spawns new processes and perhaps not completely copying the existing memory state of the process? Who knows, either way this fixes it and is inoffensive.