### PR TITLE
test: use an up to date runner to allow test action to run

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout source code


### PR DESCRIPTION
This: https://stackoverflow.com/a/70968478
Ubuntu-18.04 was deprecated on 1st April.