### PR TITLE
Remove image magick from jpg conversion code

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,6 @@ install_requires =
     pillow==9.1.0
     pyyaml==6.0
     uvicorn[standard]==0.17.6
-    wand==0.6.7
     loky==3.1.0
 
 [options.extras_require]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
 # encoding: utf-8
 import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+
 import pytest
 from PIL import Image
-from dataclasses import dataclass
 from jpegtran import JPEGImage
-from pathlib import Path
-from unittest.mock import patch, MagicMock
-from wand.exceptions import MissingDelegateError
 
-from iiif.utils import convert_image, generate_sizes, get_size, get_mimetype, parse_identifier, \
+from iiif.utils import convert_image, generate_sizes, get_size, get_mimetype, \
+    parse_identifier, \
     to_pillow, to_jpegtran, Locker, FetchCache, Fetchable
 from tests.utils import create_image, create_file
 
@@ -24,18 +24,9 @@ class TestConvertImage:
         target = tmp_path / 'converted'
         convert_image(image_path, target)
 
-        target_fallback = tmp_path / 'converted_fallback'
-        wand_mock = MagicMock(side_effect=MissingDelegateError())
-        with patch('iiif.utils.WandImage', wand_mock):
-            convert_image(image_path, target_fallback)
-
         assert target.exists()
-        assert target_fallback.exists()
         with Image.open(target) as converted_image:
             assert converted_image.format.lower() == 'jpeg'
-            with Image.open(target) as converted_fallback_image:
-                assert converted_fallback_image.format.lower() == 'jpeg'
-                assert converted_fallback_image == converted_image
 
     def test_jpeg_with_exif_orientation(self, tmp_path):
         image_path = tmp_path / 'image'
@@ -48,20 +39,10 @@ class TestConvertImage:
         target = tmp_path / 'converted'
         convert_image(image_path, target)
 
-        target_fallback = tmp_path / 'converted_fallback'
-        wand_mock = MagicMock(side_effect=MissingDelegateError())
-        with patch('iiif.utils.WandImage', wand_mock):
-            convert_image(image_path, target_fallback)
-
         assert target.exists()
-        assert target_fallback.exists()
         with Image.open(target) as converted_image:
             assert converted_image.format.lower() == 'jpeg'
             assert 0x0112 not in converted_image.getexif()
-            with Image.open(target) as converted_fallback_image:
-                assert converted_fallback_image.format.lower() == 'jpeg'
-                assert 0x0112 not in converted_fallback_image.getexif()
-                assert converted_fallback_image == converted_image
 
     def test_tiff(self, tmp_path):
         image_path = tmp_path / 'image'
@@ -71,18 +52,9 @@ class TestConvertImage:
         target = tmp_path / 'converted'
         convert_image(image_path, target)
 
-        target_fallback = tmp_path / 'converted_fallback'
-        wand_mock = MagicMock(side_effect=MissingDelegateError())
-        with patch('iiif.utils.WandImage', wand_mock):
-            convert_image(image_path, target_fallback)
-
         assert target.exists()
-        assert target_fallback.exists()
         with Image.open(target) as converted_image:
             assert converted_image.format.lower() == 'jpeg'
-            with Image.open(target) as converted_fallback_image:
-                assert converted_fallback_image.format.lower() == 'jpeg'
-                assert converted_fallback_image == converted_image
 
     def test_jpeg_options(self, tmp_path):
         image_path = tmp_path / 'image'
@@ -92,18 +64,9 @@ class TestConvertImage:
         target = tmp_path / 'converted'
         convert_image(image_path, target, quality=40, subsampling='4:2:2')
 
-        target_fallback = tmp_path / 'converted_fallback'
-        wand_mock = MagicMock(side_effect=MissingDelegateError())
-        with patch('iiif.utils.WandImage', wand_mock):
-            convert_image(image_path, target_fallback, quality=40, subsampling='4:2:2')
-
         assert target.exists()
-        assert target_fallback.exists()
         with Image.open(target) as converted_image:
             assert converted_image.format.lower() == 'jpeg'
-            with Image.open(target) as converted_fallback_image:
-                assert converted_fallback_image.format.lower() == 'jpeg'
-                assert converted_fallback_image == converted_image
 
 
 def test_generate_sizes():


### PR DESCRIPTION
Found a tiff which when converted just causes a seg fault from Image Magick due to an assertion error. Not sure why this happens so let's just remove Image Magick from the convert function and in turn just remove it completely from the project as this was the only place it was being used. Shame as it was faster than pillow, hence why it was there, but you can't catch a seg fault and without knowing why the image is causing this problem, this is the best option right now.

The tiff I found to recreate this is this original [image](https://data.nhm.ac.uk/media/bdb9d0c9-a85d-493f-8907-98e3a64ff7e4/original).


Closes #41 