### PR TITLE
Handle non-JPEG images in disk profile

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,7 @@
 [run]
 relative_files = True
+
+[report]
+exclude_lines =
+    pragma: no cover
+    @(abc\.)?abstractmethod

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # IIIF Image Server
-[![Actions](https://img.shields.io/github/workflow/status/NaturalHistoryMuseum/iiif-image-server/Tests?style=flat-square)](https://github.com/NaturalHistoryMuseum/iiif-image-server/actions)
+[![Actions](https://img.shields.io/github/actions/workflow/status/NaturalHistoryMuseum/iiif-image-server/main.yml?branch=main&style=flat-square)](https://github.com/NaturalHistoryMuseum/iiif-image-server/actions)
 [![Coveralls](https://img.shields.io/coveralls/github/NaturalHistoryMuseum/iiif-image-server/main.svg?style=flat-square)](https://coveralls.io/github/NaturalHistoryMuseum/iiif-image-server)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg?style=flat-square)](https://www.gnu.org/licenses/gpl-3.0)
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,12 @@ The names of the files must match the name part of the identifier, i.e. a reques
 fail if it is not found.
 
 #### Options
-There are no additional `disk` specific options.
+| Name                  | Description                                         | Default     |
+|-----------------------|-----------------------------------------------------|-------------|
+| `cache_for`           | How long (in seconds) to cache converted images for | `60`        |
+| `cache_size`          | Max size (in bytes) of the converted image cache    | `268435456` |
+| `convert_quality`     | JPEG quality of the converted image                 | `85`        |
+| `convert_subsampling` | subsampling value to use when converting to JPEG    | `4:2:0`     |
 
 ### mss
 This profile type is only usable by internal NHM systems on the Data Portal (and hence

--- a/iiif/profiles/disk.py
+++ b/iiif/profiles/disk.py
@@ -52,9 +52,8 @@ class OnDiskProfile(AbstractProfile):
         :param config: the config object
         :param pool: the general purpose pool for offloading processing if necessary
         :param rights: the rights definition for all images handled by this profile
-        :param cache_for: how long in seconds a client should cache the results from this profile
-                          (both info.json and image data)
-        :param cache_size: max size in bytes of the source cache on disk
+        :param cache_for: how long in seconds a client should cache the converted image
+        :param cache_size: max size in bytes of the converted image cache on disk
         :param convert_quality: quality to use when converting a source to a jpeg
         :param convert_subsampling: subsampling value to use when converting a source to a jpeg
         :param kwargs: extra kwargs for the AbstractProfile base class __init__

--- a/iiif/profiles/disk.py
+++ b/iiif/profiles/disk.py
@@ -27,7 +27,8 @@ class MissingFile(ImageNotFound):
 class OnDiskConversionFailure(IIIFServerException):
     def __init__(self, fetchable: 'Fetchable', cause: Exception):
         super().__init__(f'Failed to convert source image',
-                         log=f'Failed to convert {fetchable.public_name} due to {cause}')
+                         log=f'Failed to convert {fetchable.public_name} due to {cause}',
+                         cause=cause)
 
 
 class OnDiskProfile(AbstractProfile):

--- a/iiif/profiles/disk.py
+++ b/iiif/profiles/disk.py
@@ -145,6 +145,11 @@ class OnDiskProfile(AbstractProfile):
                     break
                 yield chunk
 
+    async def get_status(self) -> dict:
+        status = await super().get_status()
+        status['source_cache'] = await self.store.get_status()
+        return status
+
 
 @dataclass
 class OnDiskSourceFile(Fetchable):

--- a/iiif/profiles/disk.py
+++ b/iiif/profiles/disk.py
@@ -2,7 +2,7 @@ from concurrent.futures import Executor
 
 import aiofiles
 import asyncio
-import imghdr
+import filetype
 import shutil
 import tempfile
 from contextlib import asynccontextmanager
@@ -85,8 +85,8 @@ class OnDiskProfile(AbstractProfile):
         :raises: HTTPException if the file is missing
         """
         source_file_path = self._get_source(info.name)
-        source_file_type = imghdr.what(source_file_path)
-        if source_file_type == 'jpeg':
+        source_file_type = filetype.guess(source_file_path)
+        if source_file_type.mime == 'image/jpeg':
             yield source_file_path
         else:
             source = OnDiskSourceFile(info.name, source_file_path)

--- a/iiif/profiles/disk.py
+++ b/iiif/profiles/disk.py
@@ -165,9 +165,9 @@ class OnDiskSourceFile(Fetchable):
 
     @property
     def store_path(self) -> Path:
-        suffixes = self.original_file.suffixes + ['.jpg']
-        return self.original_file.with_suffix(''.join(suffixes))
-
+        filename = Path(self.name)
+        suffixes = filename.suffixes + ['.jpg']
+        return filename.with_suffix(''.join(suffixes))
 
 class OnDiskStore(FetchCache):
     def __init__(self, root: Path, pool: Executor, ttl: float, max_size: float,

--- a/iiif/profiles/disk.py
+++ b/iiif/profiles/disk.py
@@ -1,10 +1,19 @@
+from concurrent.futures import Executor
+
 import aiofiles
+import asyncio
+import imghdr
+import shutil
+import tempfile
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from functools import partial
 from pathlib import Path
 
-from iiif.exceptions import ImageNotFound
+from iiif.config import Config
+from iiif.exceptions import ImageNotFound, IIIFServerException
 from iiif.profiles.base import AbstractProfile, ImageInfo
-from iiif.utils import get_size
+from iiif.utils import get_size, FetchCache, Fetchable, convert_image
 
 
 class MissingFile(ImageNotFound):
@@ -15,11 +24,44 @@ class MissingFile(ImageNotFound):
         self.source = source
 
 
+class OnDiskConversionFailure(IIIFServerException):
+    def __init__(self, fetchable: 'Fetchable', cause: Exception):
+        super().__init__(f'Failed to convert source image',
+                         log=f'Failed to convert {fetchable.public_name} due to {cause}')
+
+
 class OnDiskProfile(AbstractProfile):
     """
     A profile representing source files that are already on disk and don't need to be fetched from
     an external source.
     """
+
+    def __init__(self,
+                 name: str,
+                 config: Config,
+                 pool: Executor,
+                 rights: str,
+                 cache_for: float = 60,
+                 cache_size: int = 1024 * 1024 * 256,
+                 convert_quality: int = 85,
+                 convert_subsampling: str = '4:2:0',
+                 **kwargs
+                 ):
+        """
+        :param name: the name of the profile, should be unique across profiles
+        :param config: the config object
+        :param pool: the general purpose pool for offloading processing if necessary
+        :param rights: the rights definition for all images handled by this profile
+        :param cache_for: how long in seconds a client should cache the results from this profile
+                          (both info.json and image data)
+        :param cache_size: max size in bytes of the source cache on disk
+        :param convert_quality: quality to use when converting a source to a jpeg
+        :param convert_subsampling: subsampling value to use when converting a source to a jpeg
+        :param kwargs: extra kwargs for the AbstractProfile base class __init__
+        """
+        super().__init__(name, config, pool, rights, cache_for, **kwargs)
+        self.store = OnDiskStore(self.cache_path / 'jpeg', pool, cache_for, cache_size,
+                                 convert_quality, convert_subsampling)
 
     async def get_info(self, name: str) -> ImageInfo:
         """
@@ -43,7 +85,14 @@ class OnDiskProfile(AbstractProfile):
         :return: the path to the source image on disk
         :raises: HTTPException if the file is missing
         """
-        yield self._get_source(info.name)
+        source_file_path = self._get_source(info.name)
+        source_file_type = imghdr.what(source_file_path)
+        if source_file_type == 'jpeg':
+            yield source_file_path
+        else:
+            source = OnDiskSourceFile(info.name, source_file_path)
+            async with self.store.use(source) as path:
+                yield path
 
     def _get_source(self, name: str) -> Path:
         """
@@ -96,3 +145,56 @@ class OnDiskProfile(AbstractProfile):
                 if not chunk:
                     break
                 yield chunk
+
+
+@dataclass
+class OnDiskSourceFile(Fetchable):
+    """
+    Fetchable subclass representing an image on disk.
+    """
+    name: str
+    original_file: Path
+
+    @property
+    def public_name(self) -> str:
+        return str(self.name)
+
+    @property
+    def store_path(self) -> Path:
+        suffixes = self.original_file.suffixes + ['.jpg']
+        return self.original_file.with_suffix(''.join(suffixes))
+
+
+class OnDiskStore(FetchCache):
+    def __init__(self, root: Path, pool: Executor, ttl: float, max_size: float,
+                 quality: int = 85, subsampling: str = '4:2:0'):
+        """
+        Note that this init will automatically call self.load() and therefore populate the cache.
+        This could take time if the cache is enormous.
+
+        :param root: the root under which all data will be stored
+        :param pool: the general purpose pool for offloading processing if necessary
+        :param ttl: how long untouched files can stay in the cache before being removed
+        :param max_size: the maximum number of bytes that can be stored in the cache
+        :param quality: jpeg quality of converted source files
+        :param subsampling: jpeg subsampling value of converted source files
+        """
+        super().__init__(root, ttl, max_size)
+        self.pool = pool
+        self._convert = partial(convert_image, quality=quality, subsampling=subsampling)
+
+    async def _fetch(self, disk_source: OnDiskSourceFile):
+        # convert the image file, saving the data in a temp file but then moving it
+        # to the source_path after the conversion is complete
+        with tempfile.NamedTemporaryFile(delete=False) as g:
+            target_path = Path(g.name)
+
+            convert = partial(self._convert, disk_source.original_file, target_path)
+            try:
+                await asyncio.get_running_loop().run_in_executor(self.pool, convert)
+            except Exception as cause:
+                raise OnDiskConversionFailure(disk_source, cause)
+
+            cache_path = self.root / disk_source.store_path
+            cache_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(target_path, cache_path)

--- a/iiif/utils.py
+++ b/iiif/utils.py
@@ -126,6 +126,7 @@ def convert_image(image_path: Path, target_path: Path, quality: int = 80,
             image.info['exif'] = exif.tobytes()
 
         target_path.parent.mkdir(parents=True, exist_ok=True)
+        image = image.convert(mode='RGB')
         image.save(target_path, format='jpeg', quality=quality, subsampling=subsampling)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ install_requires =
     cffi==1.15.0
     elasticsearch-dsl==6.4.0
     fastapi==0.77.1
+    filetype==1.2.0
     humanize==4.1.0
     # at the time of writing, the latest version of this lib on pypi (0.5.2) doesn't install
     # correctly, whereas the latest commit on master does, hence we'll just install directly from

--- a/tests/profiles/test_disk.py
+++ b/tests/profiles/test_disk.py
@@ -90,3 +90,9 @@ class TestOnDiskProfile:
         assert count == expected_count
         with path.open('rb') as f:
             assert f.read() == data
+
+    async def test_get_original_size(self, config, disk_profile):
+        path = create_image(config, 10000, 10000, 'test', 'image')
+        size = path.stat().st_size
+        profile_size = await disk_profile.resolve_original_size('image')
+        assert size == profile_size

--- a/tests/profiles/test_disk.py
+++ b/tests/profiles/test_disk.py
@@ -60,8 +60,8 @@ class TestOnDiskProfile:
         img_name = f'image_{img_mode}.{img_format}'
         info = ImageInfo('test', img_name, 100, 100)
         create_image(config, 100, 100, 'test', img_name, img_format, img_mode)
-        async with disk_profile_with_pool.use_source(info) as source_path:
-            assert source_path == disk_profile_with_pool.cache_path / 'jpeg' / (
+        async with disk_profile_with_pool.use_source(info) as converted_path:
+            assert converted_path == disk_profile_with_pool.cache_path / 'jpeg' / (
                 img_name + '.jpg')
 
     async def test_resolve_filename_no_file(self, config, disk_profile):
@@ -96,3 +96,13 @@ class TestOnDiskProfile:
         size = path.stat().st_size
         profile_size = await disk_profile.resolve_original_size('image')
         assert size == profile_size
+
+    async def test_get_status(self, config, disk_profile_with_pool):
+        img_name = 'image.tiff'
+        info = ImageInfo('test', img_name, 100, 100)
+        create_image(config, 100, 100, 'test', img_name, 'tiff')
+        async with disk_profile_with_pool.use_source(info) as converted_path:
+            size = converted_path.stat().st_size
+        status = await disk_profile_with_pool.get_status()
+        assert 'converted_cache' in status
+        assert status['converted_cache']['cache_size'] == f'{size} Bytes'

--- a/tests/profiles/test_disk_store.py
+++ b/tests/profiles/test_disk_store.py
@@ -6,7 +6,7 @@ from PIL import Image
 from pathlib import Path
 from unittest.mock import patch
 
-from iiif.profiles.disk import OnDiskStore, OnDiskSourceFile, OnDiskConversionFailure
+from iiif.profiles.disk import OnDiskStore, OnDiskConvertedFile, OnDiskConversionFailure
 
 
 @pytest.fixture
@@ -33,7 +33,7 @@ async def test_use_converts_image(source_root: Path, cache_root: Path, pool: Exe
     img = Image.new('RGB', (100, 100), color='red')
     img.save(img_path, format='tiff')
 
-    source = OnDiskSourceFile(img_name, img_path)
+    source = OnDiskConvertedFile(img_name, img_path)
     async with store.use(source) as converted_path:
         assert converted_path.exists()
         with Image.open(converted_path) as image:
@@ -57,7 +57,7 @@ async def test_use_convert_error_raises_conversion_error(source_root: Path,
     img = Image.new('RGB', (100, 100), color='red')
     img.save(img_path, format='tiff')
 
-    source = OnDiskSourceFile(img_name, img_path)
+    source = OnDiskConvertedFile(img_name, img_path)
     with pytest.raises(OnDiskConversionFailure) as exc_info:
         async with store.use(source):
             pass

--- a/tests/profiles/test_disk_store.py
+++ b/tests/profiles/test_disk_store.py
@@ -1,0 +1,56 @@
+from concurrent.futures import Executor, ProcessPoolExecutor
+
+import pytest
+from PIL import Image
+from pathlib import Path
+import os
+from unittest.mock import patch, Mock
+
+from iiif.profiles.disk import OnDiskStore, OnDiskSourceFile, OnDiskConversionFailure
+
+
+@pytest.fixture
+def source_root(tmpdir) -> Path:
+    return Path(tmpdir, 'test_src')
+
+
+@pytest.fixture
+def cache_root(tmpdir) -> Path:
+    return Path(tmpdir, 'test_cache')
+
+
+@pytest.fixture
+def pool() -> Executor:
+    return ProcessPoolExecutor(max_workers=1)
+
+
+async def test_use_converts_image(source_root: Path, cache_root: Path, pool: Executor):
+    os.mkdir(source_root)
+    store = OnDiskStore(cache_root, pool, 10, 10)
+
+    img_name = 'image.tif'
+    img_path = source_root / img_name
+    img = Image.new('RGB', (100, 100), color='red')
+    img.save(img_path, format='tiff')
+
+    source = OnDiskSourceFile(img_name, img_path)
+    async with store.use(source) as converted_path:
+        assert converted_path.exists()
+        with Image.open(converted_path) as image:
+            assert image.format.lower() == 'jpeg'
+
+
+@patch('iiif.utils.convert_image', return_value=Mock(side_effect=Exception('Oh no')))
+async def test_use_convert_error_raises_conversion_error(mock_convert, source_root: Path, cache_root: Path, pool: Executor):
+    os.mkdir(source_root)
+    store = OnDiskStore(cache_root, pool, 10, 10)
+
+    img_name = 'image.tif'
+    img_path = source_root / img_name
+    img = Image.new('RGB', (100, 100), color='red')
+    img.save(img_path, format='tiff')
+
+    source = OnDiskSourceFile(img_name, img_path)
+    with pytest.raises(OnDiskConversionFailure):
+        async with store.use(source):
+            pass

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,7 +8,7 @@ from iiif.config import Config
 
 
 def create_image(config: Config, width: int, height: int, profile: str = 'test',
-                 name: str = 'image') -> Path:
+                 name: str = 'image', img_format='jpeg', mode='RGB') -> Path:
     """
     Create a real image file for testing and returns the path to it.
 
@@ -17,12 +17,15 @@ def create_image(config: Config, width: int, height: int, profile: str = 'test',
     :param height: the height of the image to create
     :param profile: the profile name
     :param name: the image name
+    :param img_format: the image format
+    :param mode: the image mode (e.g. RGB or RGBA); will be set to RGB if format is jpeg
     :return: the path to the image
     """
     path = config.source_path / profile / name
     path.parent.mkdir(parents=True, exist_ok=True)
-    img = Image.new('RGB', (width, height), color='red')
-    img.save(path, format='jpeg')
+    mode = 'RGB' if img_format == 'jpeg' else mode
+    img = Image.new(mode, (width, height), color='red')
+    img.save(path, format=img_format)
     return path
 
 


### PR DESCRIPTION
Adds a `/jpeg` subfolder to cache directories (e.g. `/base/data/iiif/cache/vfactor/jpeg`). When a non-JPEG image is requested as a preview or thumbnail, the image is converted and stored in this cache.

Also adds these config options to the disk type:
`cache_for`: how long the converted images are stored for
`cache_size`: max size of the converted image cache
`convert_quality`: JPEG quality of the converted image
`convert_subsampling`: subsampling value to use when converting