### PR TITLE
fix: rotate images on source acquisition

### DIFF
--- a/iiif/utils.py
+++ b/iiif/utils.py
@@ -120,8 +120,10 @@ def convert_image(image_path: Path, target_path: Path, quality: int = 80,
     disable_bomb_errors()
     with Image.open(image_path) as image:
         target_path.parent.mkdir(parents=True, exist_ok=True)
-        image = ImageOps.exif_transpose(image)
+        # do this before exif_transpose to ensure tiffs get loaded and oriented before
+        # we auto-orient based on exif
         image = image.convert(mode='RGB')
+        image = ImageOps.exif_transpose(image)
         image.save(target_path, format='jpeg', quality=quality, subsampling=subsampling)
 
 

--- a/iiif/utils.py
+++ b/iiif/utils.py
@@ -14,7 +14,7 @@ from typing import Optional, Tuple, Union, Any
 
 import aiohttp
 import humanize
-from PIL import Image
+from PIL import Image, ImageOps
 from jpegtran import JPEGImage
 
 mimetypes.init()
@@ -119,13 +119,8 @@ def convert_image(image_path: Path, target_path: Path, quality: int = 80,
     # given this is usually run in a separate process, make sure we have disabled bomb errors
     disable_bomb_errors()
     with Image.open(image_path) as image:
-        if image.format.lower() == 'jpeg':
-            exif = image.getexif()
-            # this is the orientation tag, remove it if it's there
-            exif.pop(0x0112, None)
-            image.info['exif'] = exif.tobytes()
-
         target_path.parent.mkdir(parents=True, exist_ok=True)
+        image = ImageOps.exif_transpose(image)
         image = image.convert(mode='RGB')
         image.save(target_path, format='jpeg', quality=quality, subsampling=subsampling)
 


### PR DESCRIPTION
It would be good to have some more test cases for this, but from testing with the one example I have, this works fine.

Staging (running this branch): https://data-nlb-stg-01.nhm.ac.uk/media/7aeb4a93-26df-467d-91c7-555826c92885
Live (running v0.16.1): https://data.nhm.ac.uk/media/7aeb4a93-26df-467d-91c7-555826c92885

Essentially this change rotates the images on entry to the server (i.e. when we get the image from source) and strips any orientation value from the EXIF data. This puts the onus on the person putting the file into EMu and on EMu to do the right thing™️ and be consistent with any orientation tag that may or may not exist.