### PR TITLE
Update for splitgill compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ config.yml
 venv
 __pycache__
 build/
+.venv

--- a/iiif/profiles/mss.py
+++ b/iiif/profiles/mss.py
@@ -403,7 +403,7 @@ class MSSElasticsearchHandler:
         :return: the total number of hits and the first hit's source
         """
         search_url = f'{next(self.es_hosts)}/{self.mss_index}/_search'
-        search = Search().filter('term', **{'parsed.guid.^ks': guid}).extra(size=1, track_total_hits=True)
+        search = Search().filter('term', **{'data.guid._k': guid}).extra(size=1, track_total_hits=True)
         async with self.es_session.post(search_url, json=search.to_dict()) as response:
             result = await response.json(encoding='utf-8')
             total = result['hits']['total']['value']
@@ -418,7 +418,7 @@ class MSSElasticsearchHandler:
         :return: the total hits and the GUID (or None if there are no hits)
         """
         search_url = f'{next(self.es_hosts)}/{self.mss_index}/_search'
-        search = Search().filter('term', **{'parsed.old_asset_id.^ks': asset_id}).extra(size=1, track_total_hits=True)
+        search = Search().filter('term', **{'data.old_asset_id._ks': asset_id}).extra(size=1, track_total_hits=True)
         async with self.es_session.post(search_url, json=search.to_dict()) as response:
             result = await response.json(encoding='utf-8')
             total = result['hits']['total']['value']

--- a/iiif/profiles/mss.py
+++ b/iiif/profiles/mss.py
@@ -15,7 +15,7 @@ from elasticsearch_dsl import Search
 from functools import partial
 from itertools import cycle
 from pathlib import Path
-from typing import List
+from typing import List, Union
 from typing import Tuple, Optional
 from urllib.parse import quote
 
@@ -379,6 +379,50 @@ class MSSProfile(AbstractProfile):
         return status
 
 
+def rebuild_data(parsed_data: dict) -> dict:
+    """
+    Rebuild the original data that Splitgill has encoded in Elasticsearch.
+
+    :param parsed_data: the parsed dict
+    :return: the rebuilt data dict
+    """
+    # this doesn't need _ checks because you can't currently have parsed types at the
+    # root level of the data dict
+    return {key: rebuild_dict_or_list(value) for key, value in parsed_data.items()}
+
+
+def rebuild_dict_or_list(
+    value: Union[dict, list]
+) -> Union[int, str, bool, float, dict, list, None]:
+    """
+    Rebuild a dict or a list inside the parsed dict.
+
+    :param value: a dict which can either be for structure or a value, or a list of
+                  either value or structure dicts
+    :return: a dict, list, or value
+    """
+    if isinstance(value, dict):
+        if "_u" in value:
+            # this is a value dict, return the original value
+            return value["_u"]
+        else:
+            # this is a structural dict, pass each value through this function but
+            # filter out fields that start with an underscore, unless they are the
+            # special _id field
+            return {
+                key: rebuild_dict_or_list(value)
+                for key, value in value.items()
+                if not key.startswith("_") or key == "_id"
+            }
+    elif isinstance(value, list):
+        # pass each element of the list through this function
+        return [rebuild_dict_or_list(element) for element in value]
+    else:
+        # failsafe: just return the value. This should only really happen with lists
+        # containing Nones (which is technically allowed)
+        return value
+
+
 class MSSElasticsearchHandler:
     """
     Class that handles requests to Elasticsearch for the MSS profile.
@@ -408,6 +452,8 @@ class MSSElasticsearchHandler:
             result = await response.json(encoding='utf-8')
             total = result['hits']['total']['value']
             first_doc = next((doc['_source']['data'] for doc in result['hits']['hits']), None)
+            if first_doc:
+                first_doc = rebuild_data(first_doc)
             return total, first_doc
 
     async def lookup_guid(self, asset_id: str) -> Tuple[int, Optional[str]]:
@@ -418,13 +464,13 @@ class MSSElasticsearchHandler:
         :return: the total hits and the GUID (or None if there are no hits)
         """
         search_url = f'{next(self.es_hosts)}/{self.mss_index}/_search'
-        search = Search().filter('term', **{'data.old_asset_id._ks': asset_id}).extra(size=1, track_total_hits=True)
+        search = Search().filter('term', **{'data.old_asset_id._k': asset_id}).extra(size=1, track_total_hits=True)
         async with self.es_session.post(search_url, json=search.to_dict()) as response:
             result = await response.json(encoding='utf-8')
             total = result['hits']['total']['value']
             first_doc = next((doc['_source']['data'] for doc in result['hits']['hits']), None)
             if first_doc:
-                guid = first_doc['guid']
+                guid = first_doc['guid']['_u']
             else:
                 guid = None
             return total, guid

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 asyncio_mode = auto
+asyncio_default_fixture_loop_scope = "function"

--- a/tests/profiles/test_mss_es.py
+++ b/tests/profiles/test_mss_es.py
@@ -1,27 +1,36 @@
 from aioresponses import aioresponses
 
-from iiif.profiles.mss import MSSElasticsearchHandler
+from iiif.profiles.mss import MSSElasticsearchHandler, rebuild_data
 
 MOCK_HOST = 'http://not.a.real.es.host'
 MSS_INDEX = 'mss'
 
 
+def make_es_response(*hits):
+    return {
+        "hits": {
+            "total": {"value": len(hits), "relation": "eq"},
+            "hits": [{"_source": hit} for hit in hits],
+        }
+    }
+
+
 async def test_get_mss_doc():
-    mock_doc = {'a': 'doc'}
-    mock_response = {'hits': {'total': 1, 'hits': [{'_source': mock_doc}]}}
+    mock_doc = {'data': {'a': {'_u': 'doc', '_t': 'doc', '_k': 'doc'}}}
+    mock_response = make_es_response(mock_doc)
     handler = MSSElasticsearchHandler([MOCK_HOST], ['index-1', 'index-2'], mss_index=MSS_INDEX)
     try:
         with aioresponses() as m:
             m.post(f'{MOCK_HOST}/{MSS_INDEX}/_search', payload=mock_response)
             total, doc = await handler.get_mss_doc('some-guid')
             assert total == 1
-            assert doc == mock_doc
+            assert doc == rebuild_data(mock_doc['data'])
     finally:
         await handler.close()
 
 
 async def test_get_mss_doc_none_found():
-    mock_response = {'hits': {'total': 0, 'hits': []}}
+    mock_response = make_es_response()
     handler = MSSElasticsearchHandler([MOCK_HOST], ['index-1', 'index-2'], mss_index=MSS_INDEX)
     try:
         with aioresponses() as m:
@@ -34,25 +43,24 @@ async def test_get_mss_doc_none_found():
 
 
 async def test_get_mss_doc_many_found():
-    mock_docs = [{'a': 'doc'}, {'another': 'doc'}]
-    mock_response = {'hits': {'total': len(mock_docs),
-                              'hits': [{'_source': mock_doc} for mock_doc in mock_docs]}}
+    mock_docs = [{'data': {'a': {'_u': 'doc', '_t': 'doc', '_k': 'doc'}}}, {'data': {'a': {'_u': 'doc', '_t': 'doc', '_k': 'doc'}}}]
+    mock_response = make_es_response(*mock_docs)
     handler = MSSElasticsearchHandler([MOCK_HOST], ['index-1', 'index-2'], mss_index=MSS_INDEX)
     try:
         with aioresponses() as m:
             m.post(f'{MOCK_HOST}/{MSS_INDEX}/_search', payload=mock_response)
             total, doc = await handler.get_mss_doc('some-guid')
             assert total == len(mock_docs)
-            assert doc == mock_docs[0]
+            assert doc == rebuild_data(mock_docs[0]['data'])
     finally:
         await handler.close()
 
 
 async def test_cycling_hosts():
     host_1 = 'http://not.a.real.es.host1'
-    mock_response_1 = {'hits': {'total': 1, 'hits': [{'_source': {'some': 'data'}}]}}
+    mock_response_1 = make_es_response({'data': {'a': {'_u': 'doc', '_t': 'doc', '_k': 'doc'}}})
     host_2 = 'http://not.a.real.es.host2'
-    mock_response_2 = {'hits': {'total': 0, 'hits': []}}
+    mock_response_2 = make_es_response()
     handler = MSSElasticsearchHandler([host_1, host_2], ['index-1', 'index-2'],
                                       mss_index=MSS_INDEX)
     try:

--- a/tests/profiles/test_mss_store.py
+++ b/tests/profiles/test_mss_store.py
@@ -27,7 +27,7 @@ async def test_check_access_ok(source_root: Path, pool: Executor):
     emu_irn = 12345
     try:
         with aioresponses() as m:
-            m.get(MSSSourceFile.check_url(emu_irn), status=204)
+            m.get(f"{MOCK_HOST}{MSSSourceFile.check_url(emu_irn)}", status=204)
             assert await store.check_access(emu_irn)
     finally:
         await store.close()
@@ -38,7 +38,7 @@ async def test_check_access_failed(source_root: Path, pool: Executor):
     emu_irn = 12345
     try:
         with aioresponses() as m:
-            m.get(MSSSourceFile.check_url(emu_irn), status=401)
+            m.get(f"{MOCK_HOST}{MSSSourceFile.check_url(emu_irn)}", status=401)
             assert not await store.check_access(emu_irn)
     finally:
         await store.close()
@@ -53,7 +53,7 @@ async def test_stream(source_root: Path, pool: Executor):
     try:
         with aioresponses() as m:
             source = MSSSourceFile(emu_irn, file, False, chunk_size=chunk_size)
-            m.get(source.url, body=content)
+            m.get(f"{MOCK_HOST}{source.url}", body=content)
             buffer = BytesIO()
             async for chunk in store.stream(source):
                 buffer.write(chunk)
@@ -71,7 +71,7 @@ async def test_stream_access_denied(source_root, pool: Executor):
     try:
         with aioresponses() as m:
             source = MSSSourceFile(emu_irn, file, False)
-            m.get(source.url, status=401)
+            m.get(f"{MOCK_HOST}{source.url}", status=401)
             with pytest.raises(StoreStreamError) as exc_info:
                 async for chunk in store.stream(source):
                     pass
@@ -91,8 +91,8 @@ async def test_stream_missing(source_root, pool: Executor):
     try:
         with aioresponses() as m:
             source = MSSSourceFile(emu_irn, file, False)
-            m.get(source.url, status=404)
-            m.get(source.dams_url, status=404)
+            m.get(f"{MOCK_HOST}{source.url}", status=404)
+            m.get(f"{MOCK_HOST}{source.dams_url}", status=404)
             with pytest.raises(StoreStreamError) as exc_info:
                 async for chunk in store.stream(source):
                     pass
@@ -116,8 +116,8 @@ async def test_stream_use_dams(source_root: Path, pool: Executor):
     try:
         with aioresponses() as m:
             source = MSSSourceFile(emu_irn, file, True, chunk_size=chunk_size)
-            m.get(source.url, status=404)
-            m.get(source.dams_url, body=dams_url)
+            m.get(f"{MOCK_HOST}{source.url}", status=404)
+            m.get(f"{MOCK_HOST}{source.dams_url}", body=dams_url)
             m.get(dams_url, body=content)
 
             buffer = BytesIO()
@@ -138,8 +138,8 @@ async def test_stream_dams_fails(source_root: Path, pool: Executor):
     try:
         with aioresponses() as m:
             source = MSSSourceFile(emu_irn, file, True)
-            m.get(source.url, status=404)
-            m.get(source.dams_url, body=dams_url)
+            m.get(f"{MOCK_HOST}{source.url}", status=404)
+            m.get(f"{MOCK_HOST}{source.dams_url}", body=dams_url)
             m.get(dams_url, status=404)
 
             with pytest.raises(StoreStreamError) as exc_info:
@@ -166,7 +166,7 @@ async def test_use(source_root: Path, pool: Executor):
     try:
         with aioresponses() as m:
             source = MSSSourceFile(emu_irn, file, False)
-            m.get(source.url, body=buffer.getvalue())
+            m.get(f"{MOCK_HOST}{source.url}", body=buffer.getvalue())
             async with store.use(source) as path:
                 assert path.exists()
                 with Image.open(path) as image:
@@ -183,7 +183,7 @@ async def test_get_file_size(source_root: Path, pool: Executor):
 
     with aioresponses() as m:
         source = MSSSourceFile(emu_irn, file, False)
-        m.get(source.url, headers={'content-length': str(content_length)})
+        m.get(f"{MOCK_HOST}{source.url}", headers={'content-length': str(content_length)})
         assert await store.get_file_size(source) == content_length
 
 
@@ -194,6 +194,6 @@ async def test_get_file_size_fail(source_root: Path, pool: Executor):
 
     with aioresponses() as m:
         source = MSSSourceFile(emu_irn, file, False)
-        m.get(source.url, headers={})
+        m.get(f"{MOCK_HOST}{source.url}", headers={})
         with pytest.raises(StoreStreamNoLength):
             assert await store.get_file_size(source)


### PR DESCRIPTION
The document structure of the MSS data in Elasticsearch has changed courtesy of https://github.com/NaturalHistoryMuseum/splitgill/pull/24. This PR resolves that issue.