### PR TITLE
Catch timeout error

### DIFF
--- a/iiif/profiles/mss.py
+++ b/iiif/profiles/mss.py
@@ -692,6 +692,11 @@ class MSSSourceStore(FetchCache):
                     **(await response.json()),
                     'response_time': time.monotonic() - start_time,
                 }
+        except asyncio.TimeoutError:
+            status['mss_status'] = {
+                'status': 'unreachable',
+                'error': 'Timed out',
+            }
         except Exception as e:
             status['mss_status'] = {
                 'status': 'unreachable',


### PR DESCRIPTION
Using `str(e)` on a TimeoutError just returns an empty string, so this is a little more specific.